### PR TITLE
[Fix] Push event owner

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -79,7 +79,7 @@ func main() {
 			event = webhook.NewEvent(
 				pushEvent.GetHeadCommit().GetID(),
 				pushEvent.GetRepo().GetMasterBranch(),
-				pushEvent.GetPusher().GetLogin(),
+				pushEvent.GetRepo().GetOwner().GetName(),
 				pushEvent.GetRepo().GetName(),
 			)
 			options = append(options, webhook.WithApply)


### PR DESCRIPTION
- Fixed issue where event owner validity was incorrectly failing (due to using the event senders name instead of event repository owner) 